### PR TITLE
Fix issue #4 -  error information being swallowed on failed user lookup

### DIFF
--- a/source/AuthManager.ts
+++ b/source/AuthManager.ts
@@ -42,7 +42,11 @@ export class AuthManager {
         return new Promise(async function (resolve, reject) {
             // get the pool data from the response
             console.log(`Signing into AWS Cognito`);
-            this.poolData = await this.locator.getPoolForUsername(email);
+            try {
+                this.poolData = await this.locator.getPoolForUsername(email);
+            } catch (error) {
+                return reject(error);
+            }
 
             // construct a user pool object
             const userPool = new CognitoUserPool(this.poolData);
@@ -65,13 +69,13 @@ export class AuthManager {
             this.cognitoUser.authenticateUser(authenticationDetails, {
                 onSuccess(result) {
                     that.cognitoUserSession = result;
-                    resolve(result);
+                    return resolve(result);
                 },
                 onFailure(err) {
-                    reject(err);
+                    return reject(err);
                 },
                 mfaRequired(codeDeliveryDetails) { // eslint-disable-line
-                    reject(Error('Multi-factor auth is not currently supported'));
+                    return reject(Error('Multi-factor auth is not currently supported'));
                 },
                 newPasswordRequired(userAttributes, requiredAttributes) { // eslint-disable-line
                     if (newPassword !== undefined && newPassword.length > 0) {
@@ -84,10 +88,10 @@ export class AuthManager {
                         that.cognitoUser.completeNewPasswordChallenge(newPassword, userAttributes, {
                             onSuccess: function (result) {
                                 that.cognitoUserSession = result;
-                                resolve(result);
+                                return resolve(result);
                             },
                             onFailure: function(err) {
-                                reject(err);
+                                return reject(err);
                             }
                         });
                     } else {

--- a/source/CognitoUserPoolLocatorUserManagement.ts
+++ b/source/CognitoUserPoolLocatorUserManagement.ts
@@ -13,14 +13,18 @@ export class CognitoUserPoolLocatorUserManagement implements ICognitoUserPoolLoc
     public getPoolForUsername(userName: string): Promise<ICognitoUserPoolApiModel> {
         return new Promise(async function (resolve, reject) {
             const api = new UserManagementApi(process.env.USER_MANAGEMENT_URI, this.region, { type: 'None' });
-            const response: any = await api.getUserPoolByUserName(userName);
-            const result: ICognitoUserPoolApiModel = {
-                ClientId: response.data.cognito_app_client_id,
-                IdentityPoolId: response.data.cognito_identity_pool_id,
-                UserPoolId: response.data.cognito_user_pool_id
-            };
 
-            resolve(result);
+            try {
+                const response: any = await api.getUserPoolByUserName(userName);
+                const result: ICognitoUserPoolApiModel = {
+                    ClientId: response.data.cognito_app_client_id,
+                    IdentityPoolId: response.data.cognito_identity_pool_id,
+                    UserPoolId: response.data.cognito_user_pool_id
+                };
+                resolve(result);
+            } catch (error) {
+                reject(error);
+            }
         }.bind(this));
     }
 }


### PR DESCRIPTION
Signing into AWS Cognito
{"message":"Data ingestion agent initialization error: Request failed with status code 404","level":"error"}
{"message":"Axios response data: \"my.name+prod@gmail.com was not found\"","level":"debug"}
(node:19074) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: Request failed with status code 404